### PR TITLE
fix: guard against non-array port bindings in getCachedServerInfo

### DIFF
--- a/server.js
+++ b/server.js
@@ -165,7 +165,7 @@ async function getCachedServerInfo(serverId) {
   const ports = [];
   const networkPorts = info.NetworkSettings.Ports || {};
   for (const [key, bindings] of Object.entries(networkPorts)) {
-    if (!bindings) continue;
+    if (!Array.isArray(bindings)) continue;
     for (const binding of bindings) {
       ports.push({
         IP: binding.HostIp || '0.0.0.0',


### PR DESCRIPTION
Docker's NetworkSettings.Ports can return null or a non-array value for ports that are declared but not published. The previous guard only checked for falsy values, which doesn't protect against cases where bindings is a non-null non-iterable, causing 'TypeError: bindings is not iterable'.

Fix: use Array.isArray() instead of a falsy check.